### PR TITLE
Stop speech synthesis on page unload

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,13 @@
 <div id=speechWrapper>
-<div id="speechPlayer">
-  <button id="playPauseBtn" title="Воспроизвести">
-    <i class="icon-play"></i> </button>
-  <div id="progressBarContainer">
-    <div id="progressFill"></div>
+  <h2 id="speechTitle">Listen to this article</h2>
+  <div id="speechPlayer">
+    <button id="playPauseBtn" title="Воспроизвести">
+      <i class="icon-play"></i>
+    </button>
+    <div id="progressBarContainer">
+      <div id="progressFill"></div>
+    </div>
   </div>
-</div>
 </div>
 
 <p class=t220__text> Тестовый текст для озвучки</p>

--- a/script.js
+++ b/script.js
@@ -5,95 +5,188 @@ const classesToRead    = ['t220__text','t225','t004','t508','t513.t-section__tit
                           't544__title','t544__descr','t157__text'];
 const classesToExclude = ['uc-ctgr-link'];
 
-document.addEventListener('DOMContentLoaded', () => {
-  const playBtn   = document.getElementById('playPauseBtn');
-  const playIcon  = playBtn.querySelector('i');
-  const progressC = document.getElementById('progressBarContainer');
-  const progressF = document.getElementById('progressFill');
-  const synth     = window.speechSynthesis;
+class SpeechPlayer {
+  constructor(playBtn, progressC, progressF) {
+    this.playBtn = playBtn;
+    this.playIcon = playBtn.querySelector('i');
+    this.progressC = progressC;
+    this.progressF = progressF;
+    this.synth = window.speechSynthesis;
 
-  const ICON_PLAY  = 'icon-play';
-  const ICON_PAUSE = 'icon-pause';
+    if (!this.synth) {
+      console.error('Speech Synthesis not supported');
+      this.playBtn.disabled = true;
+      return;
+    }
 
-  let utter   = null;
-  let fullText = '';
-  let startOffset = 0;      
+    this.ICON_PLAY = 'icon-play';
+    this.ICON_PAUSE = 'icon-pause';
 
-  /* Собираем и кэшируем текст*/
-  function buildSelector(list) {
+    this.utter = null;
+    this.fullText = '';
+    this.startOffset = 0;
+    this.voices = [];
+
+    this.init();
+  }
+
+  init() {
+    this.playBtn.addEventListener('click', this.handlePlayPause.bind(this));
+    this.progressC.addEventListener('click', this.handleProgressClick.bind(this));
+    window.addEventListener('beforeunload', () => {
+      this.synth.cancel();
+    });
+  }
+
+  getWordIndexAtChar(charIndex) {
+    const words = Array.from(document.querySelectorAll('.word'));
+    let currentChar = 0;
+    for (let i = 0; i < words.length; i++) {
+      const word = words[i].textContent;
+      if (charIndex >= currentChar && charIndex < currentChar + word.length) {
+        return i;
+      }
+      currentChar += word.length + 1; // +1 for the space
+    }
+    return -1;
+  }
+
+
+  buildSelector(list) {
     return list.map(cls => cls.split(/\s+/).map(c => `[class~="${c}"]`).join('')).join(',');
   }
-  function collectText() {
-    const readSel = buildSelector(classesToRead);
-    const skipSel = buildSelector(classesToExclude);
-    const nodes   = document.querySelectorAll(readSel);
+
+  collectText() {
+    if (this.fullText) return this.fullText;
+
+    const readSel = this.buildSelector(classesToRead);
+    const skipSel = this.buildSelector(classesToExclude);
+    const nodes = document.querySelectorAll(readSel);
     const skipSet = new Set(document.querySelectorAll(skipSel));
 
-    let out = '';
+    let wordCount = 0;
+    const wrapWords = (node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const text = node.textContent.trim();
+        if (text) {
+          const words = text.split(/\s+/);
+          const fragment = document.createDocumentFragment();
+          words.forEach(word => {
+            const span = document.createElement('span');
+            span.className = 'word';
+            span.id = `word-${wordCount++}`;
+            span.textContent = word;
+            fragment.appendChild(span);
+            fragment.appendChild(document.createTextNode(' '));
+          });
+          node.parentNode.replaceChild(fragment, node);
+        }
+      } else if (node.nodeType === Node.ELEMENT_NODE && !skipSet.has(node) && !node.closest(skipSel)) {
+        Array.from(node.childNodes).forEach(wrapWords);
+      }
+    };
+
     nodes.forEach(n => {
-      if (!skipSet.has(n) && !n.closest(skipSel)) out += n.textContent.trim() + ' ';
+      if (!skipSet.has(n) && !n.closest(skipSel)) {
+        wrapWords(n);
+      }
     });
-    return out.trim();
+
+    this.fullText = Array.from(document.querySelectorAll('.word')).map(el => el.textContent).join(' ').replace(/\s+/g, ' ').trim();
+    return this.fullText;
   }
 
-  /* Кнопка Play/Pause */
-  function setUI(state) {
-    playIcon.classList.remove(ICON_PLAY, ICON_PAUSE);
-    playIcon.classList.add(state === 'pause' ? ICON_PAUSE : ICON_PLAY);
-    playBtn.title = state === 'pause' ? 'Пауза' : 'Воспроизвести';
+  setUI(state) {
+    this.playIcon.classList.remove(this.ICON_PLAY, this.ICON_PAUSE);
+    this.playIcon.classList.add(state === 'pause' ? this.ICON_PAUSE : this.ICON_PLAY);
+    this.playBtn.title = state === 'pause' ? 'Пауза' : 'Воспроизвести';
   }
-  function disableBtn(d = true) { playBtn.disabled = d; }
-  function setProgress(p) { progressF.style.width = Math.min(p, 100) + '%'; }
 
-  /* Обработчик вопспроизведения и перемотки */
-  function speakFrom(offset = 0) {
-    disableBtn(true);
-    synth.cancel();
+  disableBtn(d = true) {
+    this.playBtn.disabled = d;
+  }
+
+  setProgress(p) {
+    this.progressF.style.width = Math.min(p, 100) + '%';
+  }
+
+  speakFrom(offset = 0) {
+    this.disableBtn(true);
+    this.synth.cancel();
     setTimeout(() => {
-      fullText = fullText || collectText();
-      if (!fullText) { console.log('Нет текста'); setUI('stop'); disableBtn(false); return; }
+      this.collectText();
+      if (!this.fullText) {
+        console.log('Нет текста');
+        this.setUI('stop');
+        this.disableBtn(false);
+        return;
+      }
 
-      const textToSpeak = fullText.slice(offset);
-      utter = new SpeechSynthesisUtterance(textToSpeak);
-      utter.lang = 'ru-RU';
+      const textToSpeak = this.fullText.slice(offset);
+      this.utter = new SpeechSynthesisUtterance(textToSpeak);
 
-      utter.onstart = () => { setUI('pause'); disableBtn(false); };
-      utter.onend   = () => { setUI('stop'); setProgress(100);
-                              setTimeout(() => setProgress(0), 300);
-                              startOffset = 0; };
-      utter.onboundary = e => {
+      this.utter.onstart = () => {
+        this.setUI('pause');
+        this.disableBtn(false);
+      };
+      this.utter.onend = () => {
+        this.setUI('stop');
+        this.setProgress(100);
+        setTimeout(() => this.setProgress(0), 300);
+        this.startOffset = 0;
+        const wordSpans = document.querySelectorAll('.word');
+        wordSpans.forEach(span => span.classList.remove('highlight'));
+      };
+      this.utter.onboundary = e => {
         if (e.name === 'word') {
+          const wordIndex = this.getWordIndexAtChar(e.charIndex + offset);
+          if (wordIndex !== -1) {
+            const wordSpans = document.querySelectorAll('.word');
+            wordSpans.forEach(span => span.classList.remove('highlight'));
+            const wordSpan = document.getElementById(`word-${wordIndex}`);
+            if (wordSpan) {
+              wordSpan.classList.add('highlight');
+            }
+          }
           const globalIndex = offset + e.charIndex + e.charLength;
-          setProgress(globalIndex / fullText.length * 100);
+          this.setProgress((globalIndex / this.fullText.length) * 100);
         }
       };
 
-      synth.speak(utter);
+      this.synth.speak(this.utter);
     }, 50);
   }
 
-  /* Обработчки событий кнопки */
-  playBtn.addEventListener('click', () => {
-    if (synth.speaking && !synth.paused) {
-      synth.pause();
-      setUI('play');
-    } else if (synth.paused) {
-      synth.resume();
-      setUI('pause');
+  handlePlayPause() {
+    if (this.synth.speaking && !this.synth.paused) {
+      this.synth.pause();
+      this.setUI('play');
+    } else if (this.synth.paused) {
+      this.synth.resume();
+      this.setUI('pause');
     } else {
-      fullText = '';          
-      startOffset = 0;
-      speakFrom(0);
+      this.fullText = ''; // Reset cache
+      this.startOffset = 0;
+      this.speakFrom(0);
     }
-  });
+  }
 
-  /* Обработчик прогрессбара */
-  progressC.addEventListener('click', e => {
-    const rect = progressC.getBoundingClientRect();
+  handleProgressClick(e) {
+    const rect = this.progressC.getBoundingClientRect();
     const ratio = (e.clientX - rect.left) / rect.width;
-    const newOffset = Math.floor(ratio * fullText.length);
+    const newOffset = Math.floor(ratio * this.fullText.length);
 
-    startOffset = newOffset;
-    speakFrom(newOffset);
-  });
+    this.startOffset = newOffset;
+    this.speakFrom(newOffset);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const playBtn = document.getElementById('playPauseBtn');
+  const progressC = document.getElementById('progressBarContainer');
+  const progressF = document.getElementById('progressFill');
+
+  if (playBtn && progressC && progressF) {
+    new SpeechPlayer(playBtn, progressC, progressF);
+  }
 });

--- a/styles.css
+++ b/styles.css
@@ -9,11 +9,12 @@
   font-family: 'Manrope', serif;
   font-weight: 400;
 }
-    
-#speechTitle{
+
+#speechTitle {
   color: #6b7280;
   font-size: 14px;
   line-height: 20px;
+  margin: 0;
 }
     
 #speechPlayer {
@@ -24,7 +25,17 @@
   border-radius: 99px;
   width: 100%;
   max-width: 736px; /* или любая другая ширина */
-  }
+}
+
+.word {
+  display: inline-block;
+}
+
+.word.highlight {
+  background-color: yellow;
+}
+
+
   
 #playPauseBtn {
   font-size: 20px;


### PR DESCRIPTION
This commit adds a `beforeunload` event listener to the `window` object to cancel the speech synthesis when the page is about to be unloaded. This prevents the speech from continuing to play after the page has been refreshed.